### PR TITLE
Improve OpenAI integration with retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Coding Agent
 
-This repository contains a prototype coding agent for generating neural network code from architecture descriptions. The agent uses **LangChain**, **OpenAI** and **Pydantic** to parse architecture files and produce boilerplate code for data pipelines, model definitions and training scripts.
+This repository contains a prototype coding agent for generating neural network code from architecture descriptions. The agent uses **LangChain**, **langchain-openai**, **OpenAI** and **Pydantic** to parse architecture files and produce boilerplate code for data pipelines, model definitions and training scripts. Retry logic is included via **tenacity** to help avoid transient rate limit issues.
 
 ## Usage
 

--- a/neural_agent/generator.py
+++ b/neural_agent/generator.py
@@ -3,8 +3,9 @@
 from pathlib import Path
 from typing import List
 
-from langchain.chat_models import ChatOpenAI
+from langchain_openai import ChatOpenAI
 from langchain.prompts import ChatPromptTemplate
+from tenacity import retry, wait_exponential, stop_after_attempt
 
 from .architecture import Architecture
 
@@ -23,6 +24,7 @@ class CodeGenerator:
     def __init__(self, api_key: str, model: str = "gpt-3.5-turbo"):
         self.llm = ChatOpenAI(model_name=model, openai_api_key=api_key)
 
+    @retry(wait=wait_exponential(multiplier=1, min=1, max=60), stop=stop_after_attempt(6))
     def _generate(self, prompt: str) -> str:
         template = ChatPromptTemplate.from_template("{prompt}")
         chain = template | self.llm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 langchain>=0.0.220
+langchain-openai>=0.0.3
 openai>=0.27.0
 pydantic>=1.10
+tenacity>=8.2


### PR DESCRIPTION
## Summary
- switch to `langchain-openai` and add `tenacity`
- retry API calls to mitigate rate limit errors
- document new dependencies

## Testing
- `pip install -r requirements.txt`
- `python -m neural_agent.main architecture.txt --api-key sk-test` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_686c58465f108322927760b5fc9d1134